### PR TITLE
fix to avoid file_cache ImportError

### DIFF
--- a/functions/manipulate_composer/docker/manipulate_composer/compute_engine.py
+++ b/functions/manipulate_composer/docker/manipulate_composer/compute_engine.py
@@ -3,7 +3,7 @@ from .env import PROJECT_ID, ZONE, POLLING_INSTANCE_NAME
 
 
 def delete_polling_instance():
-    compute = googleapiclient.discovery.build('compute', 'v1')
+    compute = googleapiclient.discovery.build('compute', 'v1', cache_discovery=False)
     result = compute.instances().list(project=PROJECT_ID, zone=ZONE).execute()
     instance_id = ''
     for instance in result['items']:

--- a/functions/manipulate_composer/main.py
+++ b/functions/manipulate_composer/main.py
@@ -19,7 +19,7 @@ def manipulate_composer(event, context):
 
 
 def _create_polling_instance(manipulate_type):
-    compute = googleapiclient.discovery.build('compute', 'v1')
+    compute = googleapiclient.discovery.build('compute', 'v1', cache_discovery=False)
     image_response = compute.images().getFromFamily(
         project='cos-cloud', family='cos-stable').execute()
 


### PR DESCRIPTION
cloud functions実行時にauth関連のでエラーが出たため、下記サイト[1]に従ってgoogleapiclient discovery.buildの引数でファイルキャッシュを無効化しました。

> ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth

[1] https://qiita.com/kai_kou/items/4b754c61ac225daa0f7d